### PR TITLE
fix(Working Time): precision of Percent values in dashboard

### DIFF
--- a/working_time/working_time/doctype/working_time/working_time_dashboard.html
+++ b/working_time/working_time/doctype/working_time/working_time_dashboard.html
@@ -16,10 +16,10 @@
 					{% if (row[field].pct_change) { %}
 						<span class="badge {%= row[field].pct_change > 0 ? 'badge-success' : 'badge-danger' %}">
 							{%= row[field].pct_change > 0 ? '+' : '' %}
-							{%= frappe.format(row[field].pct_change, {fieldtype: "Percent"}, {inline: true}) %}
+							{%= frappe.format(row[field].pct_change, {fieldtype: "Percent", precision: "0"}, {inline: true}) %}
 						</span>
 					{% } %}
-					{%= frappe.format(row[field].value, {fieldtype: field === "billing_time_ratio" ? "Percent" : "Duration", precision: 2, hide_seconds: 1}, {inline: true}) %}
+					{%= frappe.format(row[field].value, {fieldtype: field === "billing_time_ratio" ? "Percent" : "Duration", precision: "0", hide_seconds: 1}, {inline: true}) %}
 				</td>
 			{% } %}
 		</tr>


### PR DESCRIPTION
This pull request makes a small adjustment to the formatting of percentage and duration values in the `working_time_dashboard.html` file. The change ensures that both percentage changes and value displays use zero decimal places for consistency and improved readability.

* Updated formatting for percentage change badges to use zero decimal places by setting `precision: "0"` in the call to `frappe.format`.
* Updated formatting for the main value display to use zero decimal places for both percent and duration fields by setting `precision: "0"` in the call to `frappe.format`.