### PR TITLE
fix: keep order of notes

### DIFF
--- a/working_time/working_time/doctype/working_time/test_working_time.py
+++ b/working_time/working_time/doctype/working_time/test_working_time.py
@@ -1,9 +1,72 @@
 # Copyright (c) 2023, ALYF GmbH and Contributors
 # See license.txt
 
-# import frappe
 import unittest
+
+from frappe import _dict
+
+from working_time.working_time.doctype.working_time.working_time import aggregate_time_logs
 
 
 class TestWorkingTime(unittest.TestCase):
-	pass
+	def test_aggregate_time_logs(self):
+		logs = [
+			_dict(
+				project="Project A",
+				key="KEY-1",
+				duration=3600,
+				billable="100%",
+				note="Internal Note 1",
+			),
+			_dict(
+				project="Project A",
+				key="KEY-1",
+				duration=1800,
+				billable="100%",
+				note="Internal Note 2",
+			),
+			_dict(
+				project="Project A",
+				key="KEY-1",
+				duration=1800,
+				billable="100%",
+				note="Internal Note 2",  # Duplicate, should be ignored
+			),
+			_dict(
+				project="Project A",
+				key="KEY-1",
+				duration=3600,
+				billable="100%",
+				note="Internal Note 1",  # Not consecutive, should be added
+			),
+			_dict(
+				project="Project B",
+				key="KEY-2",
+				duration=3600,
+				billable="100%",
+				note="+Customer Note 1",
+			),
+			_dict(
+				project="Project B",
+				key="KEY-2",
+				duration=3600,
+				billable="100%",
+				note="+Customer Note 1",  # Duplicate, should be ignored
+			),
+		]
+
+		result = aggregate_time_logs(logs)
+
+		# Check Project A
+		project_a = result[("Project A", "KEY-1")]
+		self.assertEqual(project_a["hours"], 3.0)
+		self.assertEqual(
+			project_a["internal_notes"], ["Internal Note 1", "Internal Note 2", "Internal Note 1"]
+		)
+		self.assertEqual(project_a["customer_notes"], [])
+
+		# Check Project B
+		project_b = result[("Project B", "KEY-2")]
+		self.assertEqual(project_b["hours"], 2.0)
+		self.assertEqual(project_b["internal_notes"], [])
+		self.assertEqual(project_b["customer_notes"], ["Customer Note 1"])

--- a/working_time/working_time/doctype/working_time/working_time.py
+++ b/working_time/working_time/doctype/working_time/working_time.py
@@ -187,8 +187,8 @@ def aggregate_time_logs(time_logs) -> dict[tuple[str | None, str | None], dict]:
 	"""Aggregate time logs by project and issue key."""
 	aggregated_time_logs = {
 		# (log.project, log.key): {
-		#     cutomer_notes: set(),
-		#     internal_notes: set(),
+		#     cutomer_notes: [],
+		#     internal_notes: [],
 		#     billable_hours: 0,
 		#     hours: 0,
 		# }
@@ -202,16 +202,20 @@ def aggregate_time_logs(time_logs) -> dict[tuple[str | None, str | None], dict]:
 			if (log.project, log.key) in aggregated_time_logs:
 				aggregated_time_logs[(log.project, log.key)]["hours"] += hours
 				aggregated_time_logs[(log.project, log.key)]["billable_hours"] += billing_hours
-				if customer_note:
-					aggregated_time_logs[(log.project, log.key)]["customer_notes"].add(customer_note)
-				if internal_note:
-					aggregated_time_logs[(log.project, log.key)]["internal_notes"].add(internal_note)
+
+				customer_notes = aggregated_time_logs[(log.project, log.key)]["customer_notes"]
+				if customer_note and (not customer_notes or customer_notes[-1] != customer_note):
+					customer_notes.append(customer_note)
+
+				internal_notes = aggregated_time_logs[(log.project, log.key)]["internal_notes"]
+				if internal_note and (not internal_notes or internal_notes[-1] != internal_note):
+					internal_notes.append(internal_note)
 			else:
 				aggregated_time_logs[(log.project, log.key)] = {
 					"hours": hours,
 					"billable_hours": billing_hours,
-					"customer_notes": {customer_note} if customer_note else set(),
-					"internal_notes": {internal_note} if internal_note else set(),
+					"customer_notes": [customer_note] if customer_note else [],
+					"internal_notes": [internal_note] if internal_note else [],
 				}
 
 	return aggregated_time_logs

--- a/working_time/working_time/doctype/working_time/working_time.py
+++ b/working_time/working_time/doctype/working_time/working_time.py
@@ -187,7 +187,7 @@ def aggregate_time_logs(time_logs) -> dict[tuple[str | None, str | None], dict]:
 	"""Aggregate time logs by project and issue key."""
 	aggregated_time_logs = {
 		# (log.project, log.key): {
-		#     cutomer_notes: [],
+		#     customer_notes: [],
 		#     internal_notes: [],
 		#     billable_hours: 0,
 		#     hours: 0,


### PR DESCRIPTION
By accumulating them in a set we lost the ordering, while the intention was just to avoid duplictes. Now we're accumulating in a list and check for duplicates explicitly.
