### PR TITLE
fix(working_time): compute duration for segments starting at midnight

### DIFF
--- a/working_time/working_time/doctype/working_time_log/working_time_log.py
+++ b/working_time/working_time/doctype/working_time_log/working_time_log.py
@@ -21,10 +21,10 @@ class WorkingTimeLog(Document):
 
 	def ensure_timedelta(self):
 		if isinstance(self.from_time, str):
-			self.from_time = to_timedelta(self.from_time) if self.from_time != "" else None
+			self.from_time = to_timedelta(self.from_time) if self.from_time else None
 
 		if isinstance(self.to_time, str):
-			self.to_time = to_timedelta(self.to_time) if self.to_time != "" else None
+			self.to_time = to_timedelta(self.to_time) if self.to_time else None
 
 	def remove_seconds(self):
 		if self.from_time is not None:

--- a/working_time/working_time/doctype/working_time_log/working_time_log.py
+++ b/working_time/working_time/doctype/working_time_log/working_time_log.py
@@ -21,18 +21,18 @@ class WorkingTimeLog(Document):
 
 	def ensure_timedelta(self):
 		if isinstance(self.from_time, str):
-			self.from_time = to_timedelta(self.from_time) if self.from_time else None
+			self.from_time = to_timedelta(self.from_time) if self.from_time != "" else None
 
 		if isinstance(self.to_time, str):
-			self.to_time = to_timedelta(self.to_time) if self.to_time else None
+			self.to_time = to_timedelta(self.to_time) if self.to_time != "" else None
 
 	def remove_seconds(self):
-		if self.from_time:
+		if self.from_time is not None:
 			self.from_time = timedelta(seconds=self.from_time.total_seconds() // 60 * 60)
 
-		if self.to_time:
+		if self.to_time is not None:
 			self.to_time = timedelta(seconds=self.to_time.total_seconds() // 60 * 60)
 
 	def set_duration(self):
-		if self.from_time and self.to_time:
+		if self.from_time is not None and self.to_time is not None:
 			self.duration = (self.to_time - self.from_time).total_seconds()


### PR DESCRIPTION
Working Time Log rows with from_time 00:00:00 kept duration 0 even when to_time was later the same day. Parent Working Time totals then ignored that segment.

**Cause:**
set_duration (and related helpers) used `if self.from_time`. timedelta(0) is falsy in Python, so midnight was skipped.

**Reproduce:**
1. Create a Working Time with a log row from 00:00:00 to a later time (e.g. 07:44:00).
2. Save the document.
3. Row duration stays 0; working_time / project_time only include other rows.

**Fix:**
use `is not None` instead of truthiness for from_time and to_time.